### PR TITLE
#deep_pluck at active model without plucking deeply will cause ArgumentError

### DIFF
--- a/lib/deep_pluck.rb
+++ b/lib/deep_pluck.rb
@@ -18,6 +18,7 @@ class ActiveRecord::Base
     hash_args, other_args = args.partition { |s| s.is_a?(Hash) }
     preloaded_model = DeepPluck::PreloadedModel.new(self, other_args)
     model = DeepPluck::Model.new(self.class.where(id: id), preloaded_model: preloaded_model)
-    return model.add(*hash_args).load_all.first
+    model.add(*hash_args) if hash_args.any?
+    return model.load_all.first
   end
 end

--- a/test/deep_pluck_test.rb
+++ b/test/deep_pluck_test.rb
@@ -211,7 +211,7 @@ class DeepPluckTest < Minitest::Test
   end
 
   def test_pluck_at_model_with_1_level_deep
-    expected = {'name' => 'Pearl' }
+    expected = {'name' => 'Pearl'}
     assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name))
   end
 

--- a/test/deep_pluck_test.rb
+++ b/test/deep_pluck_test.rb
@@ -210,7 +210,12 @@ class DeepPluckTest < Minitest::Test
     assert_equal post_expected, Post.where(id: 1).deep_pluck(:notes => [:content])
   end
 
-  def test_at_model
+  def test_pluck_at_model_with_1_level_deep
+    expected = {'name' => 'Pearl' }
+    assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name))
+  end
+
+  def test_pluck_at_model_with_2_level_deep
     expected = {'name' => 'Pearl' , :posts => [{'name' => "post4"}, {'name' => "post5"}]}
     assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name, :posts => [:name]))
   end


### PR DESCRIPTION
(The PR that supporting #deep_pluck at active model: https://github.com/khiav223577/deep_pluck/pull/19)

It works fine If you pluck deeply into associations
```rb
user.deep_pluck(:id, posts: :name)
```
But it will raise `ArgumentError` if you pluck attributes only
```rb
user.deep_pluck(:id)
```
Though you can always rewrite it by `as_json` method
```rb
user.as_json(only: :id)
```
no 🐛should live


