### PR TITLE
Fix: `id` may disappear when plucking at model instance

### DIFF
--- a/lib/deep_pluck/model.rb
+++ b/lib/deep_pluck/model.rb
@@ -10,7 +10,7 @@ module DeepPluck
       @preloaded_model = preloaded_model
       @parent_association_key = parent_association_key
       @parent_model = parent_model
-      @need_columns = []
+      @need_columns = (preloaded_model ? preloaded_model.need_columns : [])
       @associations = {}
     end
 

--- a/lib/deep_pluck/preloaded_model.rb
+++ b/lib/deep_pluck/preloaded_model.rb
@@ -1,5 +1,7 @@
 module DeepPluck
   class PreloadedModel
+    attr_reader :need_columns
+
     def initialize(active_model, need_columns)
       @active_model = active_model
       @need_columns = need_columns

--- a/test/deep_pluck_at_model_test.rb
+++ b/test/deep_pluck_at_model_test.rb
@@ -10,4 +10,10 @@ class DeepPluckAtModelTest < Minitest::Test
     expected = {'name' => 'Pearl' , :posts => [{'name' => "post4"}, {'name' => "post5"}]}
     assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name, :posts => [:name]))
   end
+
+  def test_2_level_deep_with_id
+    user = User.find_by(name: 'Pearl')
+    expected = {'id' => user.id, 'name' => 'Pearl', :posts => [{'name' => "post4"}, {'name' => "post5"}]}
+    assert_equal(expected, user.deep_pluck(:id, :name, posts: :name))
+  end
 end

--- a/test/deep_pluck_at_model_test.rb
+++ b/test/deep_pluck_at_model_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class DeepPluckAtModelTest < Minitest::Test
+  def test_1_level_deep
+    expected = {'name' => 'Pearl'}
+    assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name))
+  end
+
+  def test_2_level_deep
+    expected = {'name' => 'Pearl' , :posts => [{'name' => "post4"}, {'name' => "post5"}]}
+    assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name, :posts => [:name]))
+  end
+end

--- a/test/deep_pluck_test.rb
+++ b/test/deep_pluck_test.rb
@@ -2,13 +2,13 @@ require 'test_helper'
 
 class DeepPluckTest < Minitest::Test
   def setup
-    
+
   end
-  
+
   def test_that_it_has_a_version_number
     refute_nil ::DeepPluck::VERSION
   end
-  
+
   def test_with_none
     user_none = (ActiveRecord::Base.respond_to?(:none) ? User.none : User.where('1=0'))
     assert_equal [], user_none.deep_pluck(:id, :name)
@@ -61,13 +61,13 @@ class DeepPluckTest < Minitest::Test
 
   def test_many_to_many
     expected = [
-      {"name" => "John"     , :achievements => [{"name" => "achievement1"}]}, 
-      {"name" => "Pearl"    , :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]}, 
+      {"name" => "John"     , :achievements => [{"name" => "achievement1"}]},
+      {"name" => "Pearl"    , :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]},
       {"name" => "Kathenrie", :achievements => []},
     ]
     assert_equal expected, User.deep_pluck(:name, :achievements => :name)
     expected = [
-      {"name" => "achievement1", :users => [{"name" => "John"}, {"name" => "Pearl"}]}, 
+      {"name" => "achievement1", :users => [{"name" => "John"}, {"name" => "Pearl"}]},
       {"name" => "achievement2", :users => []},
       {"name" => "achievement3", :users => [{"name" => "Pearl"}]},
     ]
@@ -76,13 +76,13 @@ class DeepPluckTest < Minitest::Test
 
   def test_has_and_belongs_to_many
     expected = [
-      {"name" => "John"     , :achievements2 => [{"name" => "achievement1"}]}, 
-      {"name" => "Pearl"    , :achievements2 => [{"name" => "achievement1"}, {"name" => "achievement3"}]}, 
+      {"name" => "John"     , :achievements2 => [{"name" => "achievement1"}]},
+      {"name" => "Pearl"    , :achievements2 => [{"name" => "achievement1"}, {"name" => "achievement3"}]},
       {"name" => "Kathenrie", :achievements2 => []},
     ]
     assert_equal expected, User.deep_pluck(:name, :achievements2 => :name)
     expected = [
-      {"name" => "achievement1", :users2 => [{"name" => "John"}, {"name" => "Pearl"}]}, 
+      {"name" => "achievement1", :users2 => [{"name" => "John"}, {"name" => "Pearl"}]},
       {"name" => "achievement2", :users2 => []},
       {"name" => "achievement3", :users2 => [{"name" => "Pearl"}]},
     ]
@@ -91,8 +91,8 @@ class DeepPluckTest < Minitest::Test
 
   def test_with_join_and_2_level_deep
     expected = [
-      {"name" => "Pearl"    , "post_name" => "post4", :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]}, 
-      {"name" => "Pearl"    , "post_name" => "post5", :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]}, 
+      {"name" => "Pearl"    , "post_name" => "post4", :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]},
+      {"name" => "Pearl"    , "post_name" => "post5", :achievements => [{"name" => "achievement1"}, {"name" => "achievement3"}]},
       {"name" => "Kathenrie", "post_name" => "post6", :achievements => []}]
     assert_equal expected, User.where(:name => %w(Pearl Kathenrie)).joins(:posts).deep_pluck(:'users.name', :'posts.name AS post_name', :achievements => :name)
     expected = [
@@ -108,10 +108,10 @@ class DeepPluckTest < Minitest::Test
   def test_as_json_equality
     expected = User.where(:name => %w(Pearl Kathenrie)).includes([{:posts => :post_comments}, :contact]).as_json({
       :root => false,
-      :only => [:name, :email], 
+      :only => [:name, :email],
       :include => {
         'posts' => {
-          :only => :name, 
+          :only => :name,
           :include => {
             'post_comments' => {
               :only => :comment,
@@ -124,18 +124,18 @@ class DeepPluckTest < Minitest::Test
       },
     })
     assert_equal expected, User.where(:name => %w(Pearl Kathenrie)).deep_pluck(
-      :name, 
-      :email, 
-      'posts' => [:name, 'post_comments' => :comment], 
+      :name,
+      :email,
+      'posts' => [:name, 'post_comments' => :comment],
       'contact' => :address,
     )
   end
 
   def test_wrong_association_name
-    assert_raises ActiveRecord::ConfigurationError do 
+    assert_raises ActiveRecord::ConfigurationError do
       User.deep_pluck(:name, :postss => :name)
     end
-    assert_raises ActiveRecord::ConfigurationError do 
+    assert_raises ActiveRecord::ConfigurationError do
       User.deep_pluck(:name, :posts => {:post_comments2 => :comment})
     end
   end
@@ -156,13 +156,13 @@ class DeepPluckTest < Minitest::Test
 
   def test_custom_foreign_key
     expected = [
-      {"name" => "Pearl", :contact2 => {"address" => "Pearl's Home2"}}, 
+      {"name" => "Pearl", :contact2 => {"address" => "Pearl's Home2"}},
       {"name" => "Kathenrie", :contact2 => {"address" => "Kathenrie's Home2"}},
     ]
     assert_equal expected, User.where(:name => %w(Pearl Kathenrie)).deep_pluck(:name, :contact2 => :address)
     expected = [
-      {:user => {"name" => "John"     }, "address" => "John's Home2"}, 
-      {:user => {"name" => "Pearl"    }, "address" => "Pearl's Home2"}, 
+      {:user => {"name" => "John"     }, "address" => "John's Home2"},
+      {:user => {"name" => "Pearl"    }, "address" => "Pearl's Home2"},
       {:user => {"name" => "Kathenrie"}, "address" => "Kathenrie's Home2"},
     ]
     assert_equal expected, Contact2.deep_pluck(:address, :user => :name)
@@ -170,14 +170,14 @@ class DeepPluckTest < Minitest::Test
 
   def test_custom_primary_key
     expected = [
-      {:contact2_info => {"info" => "info1"}, "address" => "John's Home2"}, 
-      {:contact2_info => {"info" => "info2"}, "address" => "Pearl's Home2"}, 
+      {:contact2_info => {"info" => "info1"}, "address" => "John's Home2"},
+      {:contact2_info => {"info" => "info2"}, "address" => "Pearl's Home2"},
       {:contact2_info => {"info" => "info3"}, "address" => "Kathenrie's Home2"},
     ]
     assert_equal expected, Contact2.deep_pluck(:address, :contact2_info => :info)
     expected = [
-      {"info" => "info1", :contact2 => {:user => {'name' => 'John'}}}, 
-      {"info" => "info2", :contact2 => {:user => {'name' => 'Pearl'}}}, 
+      {"info" => "info1", :contact2 => {:user => {'name' => 'John'}}},
+      {"info" => "info2", :contact2 => {:user => {'name' => 'Pearl'}}},
       {"info" => "info3", :contact2 => {:user => {'name' => 'Kathenrie'}}},
     ]
     assert_equal expected, Contact2Info.deep_pluck(:info, :contact2 => {:user => :name})
@@ -185,15 +185,15 @@ class DeepPluckTest < Minitest::Test
 
   def test_conditional_relations
     assert_equal [
-      {"name" => "John"     , :posts_1_3 => [{"title" => "John's post1"}, {"title" => "John's post3"}]}, 
-      {"name" => "Pearl"    , :posts_1_3 => [{"title" => "Pearl's post1"}]}, 
+      {"name" => "John"     , :posts_1_3 => [{"title" => "John's post1"}, {"title" => "John's post3"}]},
+      {"name" => "Pearl"    , :posts_1_3 => [{"title" => "Pearl's post1"}]},
       {"name" => "Kathenrie", :posts_1_3 => [{"title" => "Kathenrie's post1"}]}
     ], User.deep_pluck(:name, :posts_1_3 => [:title])
   end
 
   def test_conditional_through_relations
     expected = [
-      {"name" => "achievement1", :female_users => [{"name" => "Pearl"}]}, 
+      {"name" => "achievement1", :female_users => [{"name" => "Pearl"}]},
       {"name" => "achievement2", :female_users => []},
       {"name" => "achievement3", :female_users => [{"name" => "Pearl"}]},
     ]
@@ -208,15 +208,5 @@ class DeepPluckTest < Minitest::Test
     assert_equal user_expected, User.where(id: 1).deep_pluck(:notes => [:content])
     assert_equal contact_expected, Contact.where(id: 1).deep_pluck(:note => [:content])
     assert_equal post_expected, Post.where(id: 1).deep_pluck(:notes => [:content])
-  end
-
-  def test_pluck_at_model_with_1_level_deep
-    expected = {'name' => 'Pearl'}
-    assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name))
-  end
-
-  def test_pluck_at_model_with_2_level_deep
-    expected = {'name' => 'Pearl' , :posts => [{'name' => "post4"}, {'name' => "post5"}]}
-    assert_equal(expected, User.where(:name => %w(Pearl)).first.deep_pluck(:name, :posts => [:name]))
   end
 end


### PR DESCRIPTION
Because `need_columns` is not passed from `preloaded_model`
https://github.com/khiav223577/deep_pluck/pull/19