### PR TITLE
Fix: broken test cases after bundler 2.0 was released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ gemfile:
   - gemfiles/5.2.gemfile
 before_install:
   - gem i rubygems-update -v '<3' && update_rubygems
-  - gem install bundler
+  - gem install bundler -v 1.17.3
   - gem --version
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter

--- a/deep_pluck.gemspec
+++ b/deep_pluck.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}){|f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler', '>= 1.17', '< 3.x'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'sqlite3', '~> 1.3'
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
### See https://docs.travis-ci.com/user/languages/ruby/#bundler-20:

On January 3rd 2019 the Bundler team released [Bundler 2.0](https://bundler.io/blog/2019/01/03/announcing-bundler-2.html) which dropped support for Ruby versions 2.2 and older, and added a new dependency on RubyGems 3.0.0.

If you find your builds are failing due to “bundler not installed” errors, try one of the following solutions:

If you are using a Ruby version lower than 2.3, add the following to your .travis.yml:
```yaml
  before_install:
     - gem install bundler -v '< 2'
```

If you’re using Ruby 2.3 or higher, upgrade to Bundler 2.0 by adding the following to your .travis.yml:
```yaml
  before_install:
    - gem update --system
    - gem install bundler
```
