### PR TITLE
do not publish code coverage for PRs from forks

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Run tests
       run: bundle exec rake
     - name: Publish code coverage
-      if: ${{ success() }}
+      if: ${{ success() && github.event.pull_request.head.repo.full_name == github.repository }}
       uses: paambaati/codeclimate-action@v2.7.5
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}


### PR DESCRIPTION
since they cannot access the secrets from the original repository. 
See: https://github.community/t/make-secrets-available-to-builds-of-forks/16166/30