### PR TITLE
Fix: joins incorrect table when doing inverse lookup for HABTM associations with custom name

### DIFF
--- a/deep_pluck.gemspec
+++ b/deep_pluck.gemspec
@@ -41,5 +41,5 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activerecord', '>= 3'
   spec.add_dependency 'pluck_all', '>= 1.2.3'
-  spec.add_dependency 'rails_compatibility', '>= 0.0.3'
+  spec.add_dependency 'rails_compatibility', '>= 0.0.4'
 end

--- a/test/deep_pluck_has_and_belongs_to_many_test.rb
+++ b/test/deep_pluck_has_and_belongs_to_many_test.rb
@@ -18,7 +18,9 @@ class DeepPluckHasAndBelongsToManyTest < Minitest::Test
         'name' => 'program A',
       ],
     ]
+  end
 
+  def test_custom_inverse_association_name
     assert_equal TrainingProgram.deep_pluck(:name, training_providers: :name), [
       'name' => 'program A',
       training_providers: [

--- a/test/deep_pluck_has_and_belongs_to_many_test.rb
+++ b/test/deep_pluck_has_and_belongs_to_many_test.rb
@@ -4,10 +4,26 @@ class DeepPluckHasAndBelongsToManyTest < Minitest::Test
   def setup
   end
 
-  def test_has_and_belongs_to_many
+  def test_simple_case
     assert_equal [
       { zipcodes: [{ 'city' => 'Atlanta' }, { 'city'=>'Union City' }] },
       { zipcodes: [{ 'city' => 'Minneapolis' }, { 'city'=>'Edina' }] },
     ], County.deep_pluck(zipcodes: :city)
+  end
+
+  def test_custom_association_name
+    assert_equal TrainingProvider.deep_pluck(:name, borrower_training_programs: :name), [
+      'name' => 'provider X',
+      borrower_training_programs: [
+        'name' => 'program A',
+      ],
+    ]
+
+    assert_equal TrainingProgram.deep_pluck(:name, training_providers: :name), [
+      'name' => 'program A',
+      training_providers: [
+        'name' => 'provider X',
+      ],
+    ]
   end
 end

--- a/test/deep_pluck_has_and_belongs_to_many_test.rb
+++ b/test/deep_pluck_has_and_belongs_to_many_test.rb
@@ -12,6 +12,8 @@ class DeepPluckHasAndBelongsToManyTest < Minitest::Test
   end
 
   def test_custom_association_name
+    skip if ActiveRecord::VERSION::MAJOR < 4 # Rails 3 doesn't support inverse_of options in HABTM
+
     assert_equal TrainingProvider.deep_pluck(:name, borrower_training_programs: :name), [
       'name' => 'provider X',
       borrower_training_programs: [
@@ -21,6 +23,8 @@ class DeepPluckHasAndBelongsToManyTest < Minitest::Test
   end
 
   def test_custom_inverse_association_name
+    skip if ActiveRecord::VERSION::MAJOR < 4 # Rails 3 doesn't support inverse_of options in HABTM
+
     assert_equal TrainingProgram.deep_pluck(:name, training_providers: :name), [
       'name' => 'program A',
       training_providers: [

--- a/test/lib/models/training_program.rb
+++ b/test/lib/models/training_program.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class TrainingProgram < ActiveRecord::Base
+  has_and_belongs_to_many :training_providers,
+    inverse_of: :borrower_training_programs,
+    join_table: :training_programs_training_providers
+end

--- a/test/lib/models/training_provider.rb
+++ b/test/lib/models/training_provider.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class TrainingProvider < ActiveRecord::Base
+  has_and_belongs_to_many :borrower_training_programs,
+    class_name: 'TrainingProgram',
+    inverse_of: :training_provider,
+    join_table: :training_programs_training_providers
+end

--- a/test/lib/models/training_provider.rb
+++ b/test/lib/models/training_provider.rb
@@ -3,6 +3,6 @@
 class TrainingProvider < ActiveRecord::Base
   has_and_belongs_to_many :borrower_training_programs,
     class_name: 'TrainingProgram',
-    inverse_of: :training_provider,
+    inverse_of: :training_providers,
     join_table: :training_programs_training_providers
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -178,9 +178,11 @@ County.create([
   },
 ])
 
-TrainingProgram.create!(
-  name: 'program A',
-  training_providers: [
-    TrainingProvider.create!(name: 'provider X'),
-  ],
-)
+if ActiveRecord::VERSION::MAJOR > 3 # Rails 3 doesn't support inverse_of options in HABTM
+  TrainingProgram.create!(
+    name: 'program A',
+    training_providers: [
+      TrainingProvider.create!(name: 'provider X'),
+    ],
+  )
+end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -76,6 +76,19 @@ ActiveRecord::Schema.define do
     t.string :zip, null: false
     t.string :city, null: false
   end
+
+  create_table :training_programs, force: :cascade do |t|
+    t.string :name
+  end
+
+  create_table :training_providers, force: :cascade do |t|
+    t.string :name
+  end
+
+  create_table :training_programs_training_providers, id: false, force: :cascade do |t|
+    t.references :training_provider, null: false, index: false
+    t.references :training_program, null: false, index: false
+  end
 end
 
 $optional_true = ActiveRecord::VERSION::MAJOR < 5 ? {} : { optional: true }
@@ -164,3 +177,10 @@ County.create([
     ],
   },
 ])
+
+TrainingProgram.create!(
+  name: 'program A',
+  training_providers: [
+    TrainingProvider.create!(name: 'provider X'),
+  ],
+)


### PR DESCRIPTION
Resolve #46

It looks like it is a bug in `rails_compatibility`
which is fixed in https://github.com/khiav223577/rails_compatibility/pull/8