### PR TITLE
Drop the support of ruby 2.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.2
+          - 2.3
           - 2.6
           - 2.7
           - 3.0
@@ -62,11 +62,11 @@ jobs:
           - gemfile: 5.2.gemfile
             ruby: 3.1
           - gemfile: 6.0.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 6.1.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 7.0.gemfile
-            ruby: 2.2
+            ruby: 2.3
           - gemfile: 7.0.gemfile
             ruby: 2.6
     env:
@@ -80,7 +80,6 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-          bundler: 1.17.3
       - name: Run tests
         run: bundle exec rake
       - name: Publish code coverage

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler: 1.17.3
       - name: Run tests
         run: bundle exec rake
       - name: Publish code coverage

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Allow you to pluck deeply into nested associations without loading a bunch of records.
 
 ## Supports
-- Ruby 2.2 ~ 2.7, 3.0 ~ 3.1
+- Ruby 2.3 ~ 2.7, 3.0 ~ 3.1
 - Rails 3.2, 4.2, 5.0, 5.1, 5.2, 6.0, 7.0
 
 ## Installation

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -95,6 +95,9 @@ $optional_true = ActiveRecord::VERSION::MAJOR < 5 ? {} : { optional: true }
 require 'rails_compatibility/setup_autoload_paths'
 RailsCompatibility.setup_autoload_paths [File.expand_path('../models/', __FILE__)]
 
+ActiveRecord::Base.use_yaml_unsafe_load = true if ActiveRecord::Base.method_defined?(:use_yaml_unsafe_load) # For Rails 5.2
+ActiveRecord.use_yaml_unsafe_load = true if ActiveRecord.respond_to?(:use_yaml_unsafe_load) # For Rails 7.0
+
 cities = City.create([
   { name: 'Taipei' },
 ])


### PR DESCRIPTION
since we encounter segmentation fault and have no idea how to fix it.

deep_pluck still works on Ruby 2.2 for now. But we cannot guarantee it will still work in the future.

The error messages:

```
Installing Bundler
  /opt/hostedtoolcache/Ruby/2.2.10/x64/bin/gem install bundler -v 1.17.3
  /opt/hostedtoolcache/Ruby/2.2.10/x64/lib/ruby/2.2.0/rubygems/source.rb:192: [BUG] Segmentation fault at 0x00000000000010
  ruby 2.2.10p489 (2018-03-28 revision 63023) [x86_64-linux]
```

