### PR TITLE
Fix: deep_pluck at has_many association with primary_key options will fail

### DIFF
--- a/lib/deep_pluck/model.rb
+++ b/lib/deep_pluck/model.rb
@@ -50,6 +50,8 @@ module DeepPluck
     end
 
     def get_primary_key(reflect)
+      options = reflect.options
+      return options[:primary_key] if options[:primary_key]
       return (reflect.belongs_to? ? reflect.klass : reflect.active_record).primary_key
     end
 

--- a/test/deep_pluck_primary_key_test.rb
+++ b/test/deep_pluck_primary_key_test.rb
@@ -6,9 +6,31 @@ class DeepPluckPrimaryKeyTest < Minitest::Test
 
   def test_species
     assert_equal [
-      { 'name' => 'John', 'species' => [{ 'name' => 'Bat' }, { 'name' => 'bat' }, { 'name' => 'batmen' }]},
+      { 'name' => 'John', 'species' => [{ 'name' => 'Bat' }, { 'name' => 'bat' }, { 'name' => 'batmen' }] },
       { 'name' => 'Pearl', 'species' => [] },
       { 'name' => 'Doggy', 'species' => [{ 'name' => 'Rat' }, { 'name' => 'rat' }] },
     ], User.where(name: %w[John Pearl Doggy]).deep_pluck(:name, 'species' => :name)
+  end
+
+  def test_primary_species
+    assert_equal [
+      { 'name' => 'John', 'primary_species' => { 'name' => 'Bat' }},
+      { 'name' => 'Pearl' },
+      { 'name' => 'Doggy', 'primary_species' => { 'name' => 'Rat' }},
+    ], User.where(name: %w[John Pearl Doggy]).deep_pluck(:name, 'primary_species' => :name)
+  end
+
+  def test_species_on_model
+    user = User.where(name: 'John').first
+
+    expected = { 'name' => 'John', 'species' => [{ 'name' => 'Bat' }, { 'name' => 'bat' }, { 'name' => 'batmen' }] }
+    assert_equal expected, user.deep_pluck(:name, 'species' => :name)
+  end
+
+  def test_primary_species_on_model
+    user = User.where(name: 'John').first
+
+    expected = { 'name' => 'John', 'primary_species' => { 'name' => 'Bat' }}
+    assert_equal expected, user.deep_pluck(:name, 'primary_species' => :name)
   end
 end

--- a/test/deep_pluck_primary_key_test.rb
+++ b/test/deep_pluck_primary_key_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+class DeepPluckPrimaryKeyTest < Minitest::Test
+  def setup
+  end
+
+  def test_species
+    assert_equal [
+      { 'name' => 'John', 'species' => [{ 'name' => 'Bat' }, { 'name' => 'bat' }, { 'name' => 'batmen' }]},
+      { 'name' => 'Pearl', 'species' => [] },
+      { 'name' => 'Doggy', 'species' => [{ 'name' => 'Rat' }, { 'name' => 'rat' }] },
+    ], User.where(name: %w[John Pearl Doggy]).deep_pluck(:name, 'species' => :name)
+  end
+end

--- a/test/lib/models/species.rb
+++ b/test/lib/models/species.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+class Species < ActiveRecord::Base
+end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 class User < ActiveRecord::Base
   serialize :serialized_attribute, Hash
+
   has_many :posts
+
   if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
     has_many :posts_1_3, conditions: ['title LIKE ? OR title LIKE ? ', '%post1', '%post3'], class_name: 'Post'
   else
     has_many :posts_1_3, ->{ where('title LIKE ? OR title LIKE ? ', '%post1', '%post3') }, class_name: 'Post'
   end
+
   has_one :contact
   has_one :contact2, foreign_key: :user_id2
   has_many :notes, as: :parent
@@ -20,5 +23,10 @@ class User < ActiveRecord::Base
   has_many :questionnaires
 
   has_many :species, foreign_key: :taxid, primary_key: :species_taxid
-  has_one :primary_species, ->{ where(primary: true) }, foreign_key: :taxid, primary_key: :species_taxid, class_name: 'Species'
+
+  if Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new('4.0.0')
+    has_one :primary_species, conditions: ['"primary" = ?', true], foreign_key: :taxid, primary_key: :species_taxid, class_name: 'Species'
+  else
+    has_one :primary_species, ->{ where(primary: true) }, foreign_key: :taxid, primary_key: :species_taxid, class_name: 'Species'
+  end
 end

--- a/test/lib/models/user.rb
+++ b/test/lib/models/user.rb
@@ -18,4 +18,7 @@ class User < ActiveRecord::Base
   has_one :city, through: :school
 
   has_many :questionnaires
+
+  has_many :species, foreign_key: :taxid, primary_key: :species_taxid
+  has_one :primary_species, ->{ where(primary: true) }, foreign_key: :taxid, primary_key: :species_taxid, class_name: 'Species'
 end

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define do
     t.string :name
     t.string :email
     t.string :gender
+    t.string :species_taxid
     t.integer :school_id
     t.text :serialized_attribute
   end
@@ -89,6 +90,12 @@ ActiveRecord::Schema.define do
     t.references :training_provider, null: false, index: false
     t.references :training_program, null: false, index: false
   end
+
+  create_table :species, force: true do |t|
+    t.string :name, null: false
+    t.string :taxid, null: false
+    t.boolean :primary
+  end
 end
 
 $optional_true = ActiveRecord::VERSION::MAJOR < 5 ? {} : { optional: true }
@@ -107,9 +114,9 @@ schools = School.create([
 ])
 
 users = User.create([
-  { name: 'John', email: 'john@example.com', gender: 'male', school: schools[0] },
+  { name: 'John', email: 'john@example.com', gender: 'male', school: schools[0], species_taxid: '1' },
   { name: 'Pearl', email: 'pearl@example.com', gender: 'female', serialized_attribute: { testing: true, deep: { deep: :deep }}},
-  { name: 'Doggy', email: 'kathenrie@example.com', gender: 'female' },
+  { name: 'Doggy', email: 'kathenrie@example.com', gender: 'female', species_taxid: '2' },
   { name: 'Catty', email: 'catherine@example.com', gender: 'female' },
 ])
 
@@ -180,6 +187,14 @@ County.create([
       Zipcode.new(city: 'Edina', zip: '55416'),
     ],
   },
+])
+
+Species.create!([
+  { taxid: '1', name: 'Bat', primary: true },
+  { taxid: '1', name: 'bat' },
+  { taxid: '1', name: 'batmen' },
+  { taxid: '2', name: 'Rat', primary: true },
+  { taxid: '2', name: 'rat' },
 ])
 
 if ActiveRecord::VERSION::MAJOR > 3 # Rails 3 doesn't support inverse_of options in HABTM


### PR DESCRIPTION
The error messages:

```
1) Error:
  DeepPluckPrimaryKeyTest#test_species:
NoMethodError: undefined method `[]' for nil:NilClass
    xxxxx/deep_pluck/lib/deep_pluck/data_combiner.rb:32:in `block in assign_values_to_parent'
    xxxxx/deep_pluck/lib/deep_pluck/data_combiner.rb:27:in `each'
xxxxx/deep_pluck/lib/deep_pluck/data_combiner.rb:27:in `assign_values_to_parent'
    xxxxx/deep_pluck/lib/deep_pluck/data_combiner.rb:8:in `combine_data'
    xxxxx/deep_pluck/lib/deep_pluck/model.rb:153:in `set_includes_data'
xxxxx/deep_pluck/lib/deep_pluck/model.rb:199:in `block in load_data'
    xxxxx/deep_pluck/lib/deep_pluck/model.rb:198:in `each'
    xxxxx/deep_pluck/lib/deep_pluck/model.rb:198:in `load_data'
xxxxx/deep_pluck/lib/deep_pluck/model.rb:206:in `load_all'
    xxxxx/deep_pluck/lib/deep_pluck.rb:8:in `deep_pluck'
    xxxxx/deep_pluck/test/deep_pluck_primary_key_test.rb:12:in `test_species'
```