### PR TITLE
Always show the association key even if there is no data

### DIFF
--- a/lib/deep_pluck/data_combiner.rb
+++ b/lib/deep_pluck/data_combiner.rb
@@ -4,29 +4,29 @@ module DeepPluck
       def combine_data(parent, children, primary_key, column_name, foreign_key, reverse, collection)
         source =  reverse ? parent : children
         target = !reverse ? parent : children
-        data_hash = make_data_hash(collection, source, primary_key, column_name)
+        data_hash = make_data_hash(collection, source, primary_key, column_name, reverse)
         assign_values_to_parent(collection, target, data_hash, column_name, foreign_key, reverse: reverse)
         return children
       end
 
       private
 
-      def make_data_hash(collection, parent, primary_key, column_name)
+      def make_data_hash(collection, parent, primary_key, column_name, reverse)
         hash = {}
 
-        if collection
-          parent.each do |model_hash|
-            key = model_hash[primary_key]
-            array = (hash[key] ? hash[key][column_name] : []) # share the children if id is duplicated
-            model_hash[column_name] = array # set the value of this association key to empty array by default
-            hash[key] = model_hash
+        parent.each do |model_hash|
+          key = model_hash[primary_key]
+
+          if reverse
+            if collection
+              array = (hash[key] ? hash[key][column_name] : []) # share the children if id is duplicated
+              model_hash[column_name] = array # set the value of this association key to empty array by default
+            else
+              model_hash[column_name] = nil # set the value of this association key to be nil by default
+            end
           end
-        else
-          parent.each do |model_hash|
-            key = model_hash[primary_key]
-            model_hash[column_name] ||= nil # set the value of this association key to be nil by default
-            hash[key] = model_hash
-          end
+
+          hash[key] = model_hash
         end
 
         return hash

--- a/lib/deep_pluck/data_combiner.rb
+++ b/lib/deep_pluck/data_combiner.rb
@@ -33,10 +33,12 @@ module DeepPluck
       end
 
       def assign_values_to_parent(collection, parent, children_hash, column_name, foreign_key, reverse: false)
-        parent.each do |s|
-          next if (id = s[foreign_key]) == nil
-          left = reverse ? children_hash[id] : s
-          right = !reverse ? children_hash[id] : s
+        parent.each do |data|
+          id = data[foreign_key]
+
+          left = reverse ? children_hash[id] : data
+          right = !reverse ? children_hash[id] : data
+
           if collection
             left[column_name] << right
           else

--- a/lib/deep_pluck/data_combiner.rb
+++ b/lib/deep_pluck/data_combiner.rb
@@ -12,14 +12,23 @@ module DeepPluck
       private
 
       def make_data_hash(collection, parent, primary_key, column_name)
-        return parent.map{|s| [s[primary_key], s] }.to_h if !collection
         hash = {}
-        parent.each do |model_hash|
-          key = model_hash[primary_key]
-          array = (hash[key] ? hash[key][column_name] : []) # share the children if id is duplicated
-          model_hash[column_name] = array
-          hash[key] = model_hash
+
+        if collection
+          parent.each do |model_hash|
+            key = model_hash[primary_key]
+            array = (hash[key] ? hash[key][column_name] : []) # share the children if id is duplicated
+            model_hash[column_name] = array # set the value of this association key to empty array by default
+            hash[key] = model_hash
+          end
+        else
+          parent.each do |model_hash|
+            key = model_hash[primary_key]
+            model_hash[column_name] ||= nil # set the value of this association key to be nil by default
+            hash[key] = model_hash
+          end
         end
+
         return hash
       end
 

--- a/test/deep_pluck_has_and_belongs_to_many_test.rb
+++ b/test/deep_pluck_has_and_belongs_to_many_test.rb
@@ -8,6 +8,7 @@ class DeepPluckHasAndBelongsToManyTest < Minitest::Test
     assert_equal [
       { zipcodes: [{ 'city' => 'Atlanta' }, { 'city'=>'Union City' }] },
       { zipcodes: [{ 'city' => 'Minneapolis' }, { 'city'=>'Edina' }] },
+      { zipcodes: [] },
     ], County.deep_pluck(zipcodes: :city)
   end
 

--- a/test/deep_pluck_has_one_through_test.rb
+++ b/test/deep_pluck_has_one_through_test.rb
@@ -7,7 +7,7 @@ class DeepPluckHasOneThroughTest < Minitest::Test
   def test_belongs_to_through_belongs_to # user belongs_to school, school belongs to city
     assert_equal [
       { 'name' => 'John', 'city' => { 'name' => 'Taipei' }},
-      { 'name' => 'Pearl' },
+      { 'name' => 'Pearl', 'city' => nil },
     ], User.where(name: %w[John Pearl]).deep_pluck(:name, 'city' => :name)
   end
 

--- a/test/deep_pluck_primary_key_test.rb
+++ b/test/deep_pluck_primary_key_test.rb
@@ -15,7 +15,7 @@ class DeepPluckPrimaryKeyTest < Minitest::Test
   def test_primary_species
     assert_equal [
       { 'name' => 'John', 'primary_species' => { 'name' => 'Bat' }},
-      { 'name' => 'Pearl' },
+      { 'name' => 'Pearl', 'primary_species' => nil },
       { 'name' => 'Doggy', 'primary_species' => { 'name' => 'Rat' }},
     ], User.where(name: %w[John Pearl Doggy]).deep_pluck(:name, 'primary_species' => :name)
   end

--- a/test/deep_pluck_test.rb
+++ b/test/deep_pluck_test.rb
@@ -161,21 +161,24 @@ class DeepPluckTest < Minitest::Test
     expected = [
       { 'name' => 'Pearl', :contact2 => { 'address' => "Pearl's Home2" }},
       { 'name' => 'Doggy', :contact2 => { 'address' => "Doggy's Home2" }},
+      { 'name' => 'Catty', :contact2 => nil },
     ]
-    assert_equal expected, User.where(name: %w[Pearl Doggy]).deep_pluck(:name, contact2: :address)
+    assert_equal expected, User.where(name: %w[Pearl Doggy Catty]).deep_pluck(:name, contact2: :address)
     expected = [
-      { :user => { 'name' => 'John'     }, 'address' => "John's Home2" },
-      { :user => { 'name' => 'Pearl'    }, 'address' => "Pearl's Home2" },
-      { :user => { 'name' => 'Doggy' }, 'address' => "Doggy's Home2" },
+      { 'address' => "John's Home2", :user => { 'name' => 'John' } },
+      { 'address' => "Pearl's Home2", :user => { 'name' => 'Pearl' } },
+      { 'address' => "Doggy's Home2", :user => { 'name' => 'Doggy' },  },
+      { 'address' => "no one's Home2", :user => nil },
     ]
     assert_equal expected, Contact2.deep_pluck(:address, user: :name)
   end
 
   def test_custom_primary_key
     expected = [
-      { :contact2_info => { 'info' => 'info1' }, 'address' => "John's Home2" },
-      { :contact2_info => { 'info' => 'info2' }, 'address' => "Pearl's Home2" },
-      { :contact2_info => { 'info' => 'info3' }, 'address' => "Doggy's Home2" },
+      { 'address' => "John's Home2", :contact2_info => { 'info' => 'info1' } },
+      { 'address' => "Pearl's Home2", :contact2_info => { 'info' => 'info2' } },
+      { 'address' => "Doggy's Home2", :contact2_info => { 'info' => 'info3' } },
+      { 'address' => "no one's Home2", :contact2_info => nil },
     ]
     assert_equal expected, Contact2.deep_pluck(:address, contact2_info: :info)
     expected = [

--- a/test/deep_pluck_test.rb
+++ b/test/deep_pluck_test.rb
@@ -34,7 +34,7 @@ class DeepPluckTest < Minitest::Test
     assert_equal [
       { 'name' => 'John', :contact => { 'address' => "John's Home" }},
       { 'name' => 'Pearl', :contact => { 'address' => "Pearl's Home" }},
-      { 'name' => 'Catty' },
+      { 'name' => 'Catty', :contact => nil },
     ], User.where(name: %w[John Pearl Catty]).deep_pluck(:name, contact: :address)
   end
 

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -146,6 +146,7 @@ contact2 = Contact2.create([
   { address: "John's Home2", phone_number: '0911666888', user_id2: users[0].id },
   { address: "Pearl's Home2", phone_number: '1011-0404-934', user_id2: users[1].id },
   { address: "Doggy's Home2", phone_number: '02-254421', user_id2: users[2].id },
+  { address: "no one's Home2", phone_number: '??', user_id2: nil },
 ])
 
 Contact2Info.create([

--- a/test/lib/seeds.rb
+++ b/test/lib/seeds.rb
@@ -187,6 +187,9 @@ County.create([
       Zipcode.new(city: 'Edina', zip: '55416'),
     ],
   },
+  {
+    name: 'unknown',
+  }
 ])
 
 Species.create!([


### PR DESCRIPTION
Something if we deep_pluck a model with assocation, Ex:
```rb
User.deep_pluck(:name, 'city' => :name)
```

The result hash may not contain 'city' key in that the user doesn't have a city. Ex: 
```
{ 'name' => 'Pearl' }
```

We want the result always contain the key, Ex:
```
{ 'name' => 'Pearl', 'city' => nil }
```