### PR TITLE
Deal with the parameter handling which was changed in Rails 7.0.6

### DIFF
--- a/deep_pluck.gemspec
+++ b/deep_pluck.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest', '~> 5.0'
 
   spec.add_dependency 'activerecord', '>= 3'
-  spec.add_dependency 'pluck_all', '>= 2.3.2'
+  spec.add_dependency 'pluck_all', '>= 2.3.4'
   spec.add_dependency 'rails_compatibility', '>= 0.0.8'
 end

--- a/gemfiles/7.0.gemfile
+++ b/gemfiles/7.0.gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'zeitwerk'
-gem 'activerecord', '~> 7.0.0'
+gem 'activerecord', '~> 7.0.8'
 gem 'pluck_all', '~> 2.3.2'
 
 # gem 'globalize',  '~> 6.0.1' # TODO: wait for globalize to support Rails 7.


### PR DESCRIPTION
Resolve #62 

It was fixed in pluck_all, so we update the dependency.

See: https://github.com/khiav223577/pluck_all/pull/61